### PR TITLE
config.php - allow configuration changes from external ini file

### DIFF
--- a/config.php
+++ b/config.php
@@ -36,7 +36,7 @@ $conf['blockpage_url'] = get_config('blockpage_url', "");
 // connection is "not secure." It's highly reccomended that you change this.
 // Example: "https://example.com/blockpage/"
 
-$conf['unblock_url'] = get_config('unblock-exec', "unblock-exec");
+$conf['unblock_url'] = get_config('unblock-url', "unblock-exec");
 // In most cases this does not have to be changed. Only change it if your
 // unblock page resides in a subpath which is not "unblock-exec"
 

--- a/config.php
+++ b/config.php
@@ -8,38 +8,56 @@ NOTE: All PiPass files are dependent upon this one configuration file. Your
 changes will be widespread!
 */
 
-$conf['show_tech_info'] = true;
+$ini_path = "{$_SERVER['HOME']}/.config/PiPass/PiPass.ini";
+$ini = [];
+
+// If the ini file exists, use it. If not, create an empty $ini array so
+// checks against it fail.
+if ( file_exists($ini_path) ) {
+  $ini = parse_ini_file($ini_path);
+}
+
+function get_config($section, $defaultValue) {
+  global $ini;
+  if ( array_key_exists($section , $ini) == true ) {
+    return $ini[$section];
+  } else {
+    return $defaultValue;
+  }
+}
+
+$conf['show_tech_info'] = get_config('show_tech_info', true);
 // Should usually be set to true, unless you have specific reason to disable
 // it. Determines whether the program should show technical info.
 
-$conf['blockpage_url'] = "";
+$conf['blockpage_url'] = get_config('blockpage_url', "");
 // The URL (not directory) of your blockpage. Setting this incorrectly can
 // lead to SSL certificate SAN errors, which prompt the user that the
 // connection is "not secure." It's highly reccomended that you change this.
 // Example: "https://example.com/blockpage/"
 
-$conf['unblock_url'] = "unblock-exec";
+$conf['unblock_url'] = get_config('unblock-exec', "unblock-exec");
 // In most cases this does not have to be changed. Only change it if your
 // unblock page resides in a subpath which is not "unblock-exec"
 
-$conf['safeurl'] = "about:home";
+$conf['safeurl'] = get_config('safeurl', "about:home");
 // Enter a URL of your choice to go to when a user clicks "back to safety"
 // This should not be a directory.
 
-$conf['adminemail'] = "";
+$conf['adminemail'] = get_config('adminemail', "");
 // Your email. Used when a user requests a permanent unblock.
 
-$conf['timezone'] = date_default_timezone_set("America/New_York");
+$conf['timezone'] = date_default_timezone_set(get_config('timezone', "America/New_York"));
 // Your timezone. Used when displaying technical info.
 
-$conf['date'] = date('m/d/Y h:i:s a', time());
+$conf['date'] = date(get_config('date', 'm/d/Y h:i:s a'), time());
 // Format in which the date/time is presented to end users.
 
-$conf['unblock_seconds'] = 7200;
+$conf['unblock_seconds'] = get_config('unblock_seconds', 7200);
 // How many seconds to unblock a website for when a temporary unblock is
 // executed by a user.
 
-$conf['time_friendly'] = "2 hours";
+$conf['time_friendly'] = get_config('time_friendly', "2 hours");
 // A way of saying the amount of unblock seconds in english.
 // For example, 300 seconds would equal 5 minutes.
 


### PR DESCRIPTION
This change will allow configuration from an ini file. The default path will be ~/.config/PiPass/PiPass.ini

All fields except version should be able to configured. If the user does not have an ini file, use supplied defaults. 

Ini section and available fields:

[pi_pass]
show_tech_info
blockpage_url
unblock_url
safeurl
adminemail
timezone
date
unblock_seconds
time_friendly


Note that this should work, but I have not thoroughly tested it.