### PR TITLE
Setup: More modifications. Backup files, put PiPass in it's own directory

### DIFF
--- a/config.php
+++ b/config.php
@@ -30,7 +30,7 @@ $conf['show_tech_info'] = get_config('show_tech_info', true);
 // Should usually be set to true, unless you have specific reason to disable
 // it. Determines whether the program should show technical info.
 
-$conf['blockpage_url'] = get_config('blockpage_url', "");
+$conf['blockpage_url'] = get_config('blockpage_url', "index.php");
 // The URL (not directory) of your blockpage. Setting this incorrectly can
 // lead to SSL certificate SAN errors, which prompt the user that the
 // connection is "not secure." It's highly reccomended that you change this.

--- a/setup/setup.php
+++ b/setup/setup.php
@@ -109,11 +109,23 @@ function install() {
     exec("cd $drf_local && sudo git checkout tags/v$latestVersion");
     if ( file_exists('/etc/lighttpd/lighttpd.conf') == true ) {
 		echo "[ + ] Lighttpd web server detected. Modifying 404 redirects.\n";
+		if (!file_exists('/etc/lighttpd/lighttpd.conf.pipass.bak')) {
+			echo "[ + ] No lighttpd.conf backup found for PiPass. Backing up before modifying.";
+			exec("sudo cp /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.pipass.bak");
+		}
 		exec('sudo sed -i /etc/lighttpd/lighttpd.conf -re \'s/(server.error-handler-404[^"]*")([^"]*)(")/\1index\.php\3/\'');
-		echo "[ + ] Modifying PiHole FTL to BLOCKINGMODE=IP\n";
-		exec('sudo sed -i \'/^BLOCKINGMODE=/{h;s/=.*/=IP/};${x;/^$/{s//BLOCKINGMODE=IP/;H};x}\' /etc/pihole/pihole-FTL.conf');
 	} else {
 		echo "[ - ] Did not detect PiHole's default webserver 'Lighttpd'. Please configure installed web server to redirect 404's to PiPass.\n";
+	}
+	if (file_exists('/etc/pihole/pihole-FTL.conf')) {
+		echo "[ + ] Modifying PiHole FTL to BLOCKINGMODE=IP\n";
+		if (!file_exists('/etc/pihole/pihole-FTL.conf.pipass.bak')) {
+			echo "[ + ] No pihole-FTL.conf backup found for PiPass. Backing up before modifying.";
+			exec("sudo cp /etc/pihole/pihole-FTL.conf /etc/pihole/pihole-FTL.conf.pipass.bak");
+		}
+		exec('sudo sed -i \'/^BLOCKINGMODE=/{h;s/=.*/=IP/};${x;/^$/{s//BLOCKINGMODE=IP/;H};x}\' /etc/pihole/pihole-FTL.conf');
+	} else {
+		echo "[ - ] Did not detect PiHole FTL.";
 	}
     echo "[ + ] Selected version v$latestVersion\n";
     echo "[ + ] Installation complete. Please set your webserver to redirect all 404 pages to the homepage (web root). This function is not automated yet.\n";

--- a/setup/uninstall.php
+++ b/setup/uninstall.php
@@ -1,0 +1,23 @@
+<?php
+echo "[ + ] Commencing uninstallation of PiPass."
+echo "[ + ] We're sad to see you go... please help improve this project by leaving feedback on what issues casued you to leave.";
+$GLOBALS['phpuser'] = get_current_user();
+$localPU = $GLOBALS['phpuser'];
+$sudoersline = preg_quote("$localPU ALL=(ALL) NOPASSWD: /usr/local/bin/pihole -w *, /usr/local/bin/pihole -w -d *", '/,');
+echo "[ + ] Removing PiPass entry from /etc/suoders";
+exec("sudo sed -ri '/$sudoersline/d' /etc/sudoers");
+
+if (file_exists('/var/www/html/blockpage')) {
+echo "[ + ] Removing PiPass files...";
+exec("cd /var/www/html && sudo rm -rf index.php config.php setup blockpage");
+}
+if (file_exists('/etc/lighttpd/lighttpd.conf.pipass.bak')) {
+echo "[ + ] Restoring backup of lighttpd.conf";
+exec("sudo mv /etc/lighttpd/lighttpd.conf.pipass.bak /etc/lighttpd/lighttpd.conf");
+}
+if (file_exists('/etc/pihole/pihole-FTL.conf.pipass.bak')) {
+echo "[ + ] Restoring backup of pihole-FTL.conf";
+exec("sudo mv /etc/pihole/pihole-FTL.conf.pipass.bak /etc/pihole/pihole-FTL.conf");
+}
+echo "[ + ] PiPass has been uninstalled."
+?>


### PR DESCRIPTION
There's no reason that PiPass would need to be in the base directory (as far as I can tell). Go ahead and put it in one directory and update the install scripts to point the 404 redirect there. This should also prevent PiPass from interfering with any existing webpages outside of the 404 redirection.

This will allow the uninstall to consist of:
delete 'webroot'/PiPass
rename the backed up files 'xxxxx'.pipass.bak to the original filenames
remove the line that was added to the sudoers file.

Note: the files being backed up would only apply to installations going forward. If they're already modified, they would be backed up with those modifications.