### PR TITLE
Locales beta - Get language from the end-user's browser.

### DIFF
--- a/blockpage/index.php
+++ b/blockpage/index.php
@@ -1,7 +1,7 @@
 <?php
 require('../config.php');
 
-$usrLanguage = $conf['language'];
+$usrLanguage = get_language();
 require("../locale/locale-$usrLanguage.php");
 
 if(isset($_GET['url'])) {

--- a/blockpage/unblock-exec/index.php
+++ b/blockpage/unblock-exec/index.php
@@ -1,7 +1,7 @@
 <?php
 require('../../config.php');
 
-$usrLanguage = $conf['language'];
+$usrLanguage = get_language();
 require("../../locale/locale-$usrLanguage.php");
 
 $GLOBALS['unblockTimeSec'] = $conf['unblock_seconds'];

--- a/config.php
+++ b/config.php
@@ -27,6 +27,21 @@ function get_config($section, $defaultValue) {
   }
 }
 
+function get_language() {
+    $lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+    $files = array_values(array_diff(scandir('locale'), array('..', '.')));
+    $translations = array();
+    
+    for ($i = 0; $i < count($files); $i++) {
+		$str = "$files[$i]";
+		if (preg_match('/locale-([a-z][a-z]).php/', $str, $match) == 1) {
+			$translations[] = $match[1];
+		}
+	}
+	$lang = in_array($lang, $translations) ? $lang : $conf['language'];
+	return $lang;
+}
+
 $conf["language"] = get_config('language', "en");
 // Default/fallback language to use in PiPass. Should be in IEFT language format.
 

--- a/config.php
+++ b/config.php
@@ -28,7 +28,7 @@ function get_config($section, $defaultValue) {
 }
 
 $conf["language"] = get_config('language', "en");
-// Language to use in PiPass. Should be in IEFT language format.
+// Default/fallback language to use in PiPass. Should be in IEFT language format.
 
 $conf['show_tech_info'] = get_config('show_tech_info', true);
 // Should usually be set to true, unless you have specific reason to disable


### PR DESCRIPTION
I like the idea here, translations should definitely be a thing.

This should scan all of the locale-xx.php files in the locales folder, add them to an array and select the desired language based on what the end-user has set up in their browser. If there's no matching translation, default to the one that was specified in the configuration. 

The format will have to be ISO-639-1 for the 2 letter codes, see here: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes

This default locale file WILL have to exist and there are currently no checks to ensure that. We could protect against that, but at what point are we just protecting people from themselves.